### PR TITLE
Enhancement/context path - take <base href=".."> into account when getting worker path

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,10 +94,24 @@ function createLoaderRules(languages, features, workers, publicPath) {
   const workerPaths = workers.reduce((acc, { label, output }) => Object.assign(acc, {
     [label]: `${publicPath ? `${stripTrailingSlash(publicPath)}/` : ''}${output}`,
   }), {});
+
+  const getBasePath = () => {
+    const bases = document.getElementsByTagName('base');
+    let contextPath = '/';
+    if (bases.length) {
+      contextPath = bases[0].getAttribute('context') || bases[0].href || '/';
+    }
+    return contextPath;
+  }
+
+  const getWorkerPath = (workerPath) => {
+    return `${getBasePath()}/${workerPath}`.replace('//', '/');
+  }
+
   const globals = {
-    'MonacoEnvironment': `((paths) => ({ getWorkerUrl: (moduleId, label) => paths[label] }))(${
+    'MonacoEnvironment': `((paths) => ({ getWorkerUrl: (moduleId, label) => ${getWorkerPath(paths[label])}}))(${
       JSON.stringify(workerPaths, null, 2)
-    })`,
+      })`,
   };
   return [
     {

--- a/index.js
+++ b/index.js
@@ -95,24 +95,32 @@ function createLoaderRules(languages, features, workers, publicPath) {
     [label]: `${publicPath ? `${stripTrailingSlash(publicPath)}/` : ''}${output}`,
   }), {});
 
-  const getBasePath = () => {
-    const bases = document.getElementsByTagName('base');
-    let contextPath = '/';
-    if (bases.length) {
-      contextPath = bases[0].getAttribute('context') || bases[0].href || '/';
-    }
-    return contextPath;
-  }
-
   const getWorkerPath = (workerPath) => {
-    return `${getBasePath()}/${workerPath}`.replace('//', '/');
-  }
+    const getBasePath = () => {
+      const bases = document.getElementsByTagName('base');
+      let contextPath = '/';
+      if (bases.length) {
+        contextPath = bases[0].getAttribute('context') || bases[0].href || '/';
+      }
+      return contextPath;
+    };
+
+    const basePath = getBasePath();
+    if (basePath[basePath.length - 1] !== '/') {
+      basePath = `${basePath}/`;
+    }
+    if (workerPath[0] === '/') {
+      workerPath = workerPath.substr(1);
+    }
+
+    const contextPath = basePath + workerPath;
+    return contextPath;
+  };
 
   const globals = {
-    'MonacoEnvironment': `((paths) => ({ getWorkerUrl: (moduleId, label) => ${getWorkerPath(paths[label])}}))(${
-      JSON.stringify(workerPaths, null, 2)
-      })`,
+    'MonacoEnvironment': `((paths) => ({ getWorkerUrl: (moduleId, label) => (${getWorkerPath.toString()})(paths[label]) }))(${JSON.stringify(workerPaths, null, 2)})`
   };
+
   return [
     {
       test: MONACO_EDITOR_API_PATHS,


### PR DESCRIPTION
*tl;dr*
Check if there is a `<base>` tag and use it's path as the prefix to the worker paths.

# Details
It's a little ugly in # loc because of the back tick syntax for the dynamic editor options.