### PR TITLE
Fix worker output path in loader rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Monaco Editor Webpack Loader Plugin
 
-A plugin to simplify loading the [Monaco Editor](https://github.com/Microsoft/monaco-editor) with [webpack](https://webpack.js.org/) contributed by [Tim Kendrik](https://github.com/timkendrick).
+A plugin to simplify loading the [Monaco Editor](https://github.com/Microsoft/monaco-editor) with [webpack](https://webpack.js.org/).
 
 ## Installing
 ```sh
@@ -38,7 +38,7 @@ monaco.editor.create(document.getElementById('container'), {
 
 Options can be passed in to `MonacoWebpackPlugin`. They can be used to generate a smaller editor bundle by selecting only certain languages or only certain editor features:
 
-* `output` (`string`) - append a certain string to all generated files.
+* `output` (`string`) - custom output path for worker scripts, relative to the main webpack `output.path`.
   * default value: `''`.
 * `languages` (`string[]`) - include only a subset of the languages supported.
   * default value: `['bat', 'coffee', 'cpp', 'csharp', 'csp', 'css', 'dockerfile', 'fsharp', 'go', 'handlebars', 'html', 'ini', 'java', 'json', 'less', 'lua', 'markdown', 'msdax', 'mysql', 'objective', 'pgsql', 'php', 'postiats', 'powershell', 'pug', 'python', 'r', 'razor', 'redis', 'redshift', 'ruby', 'sb', 'scss', 'solidity', 'sql', 'swift', 'typescript', 'vb', 'xml', 'yaml']`.

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ class MonacoWebpackPlugin {
     const workers = modules.map(
       ({ label, alias, worker }) => worker && ({ label, alias, ...worker })
     ).filter(Boolean);
-    const rules = createLoaderRules(languages, features, workers, publicPath);
+    const rules = createLoaderRules(languages, features, workers, output, publicPath);
     const plugins = createPlugins(workers, output);
     addCompilerRules(compiler, rules);
     addCompilerPlugins(compiler, plugins);
@@ -83,11 +83,11 @@ function getPublicPath(compiler) {
   return compiler.options.output && compiler.options.output.publicPath || '';
 }
 
-function createLoaderRules(languages, features, workers, publicPath) {
+function createLoaderRules(languages, features, workers, outputPath, publicPath) {
   if (!languages.length && !features.length) { return []; }
   const languagePaths = languages.map(({ entry }) => entry).filter(Boolean);
   const featurePaths = features.map(({ entry }) => entry).filter(Boolean);
-  const workerPaths = fromPairs(workers.map(({ label, output }) => [label, output]));
+  const workerPaths = fromPairs(workers.map(({ label, output }) => [label, path.join(outputPath, output)]));
 
   const globals = {
     'MonacoEnvironment': `(function (paths) {


### PR DESCRIPTION
I originally added an `output` option to control the output directory for the worker scripts, but I accidentally forgot this when generating the loader rules. This means the `MonacoEnvironment.getWorkerUrl` will incorrectly return the filename within the webpack public root, rather than the user-specified worker root.

This PR should allow you to use a custom `output` option to generate the worker scripts in a different path.