### PR TITLE
Add support for Node 6 LTS

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,10 +37,10 @@ function resolveMonacoPath(filePath) {
 
 const languagesById = fromPairs(
   flatMap(toPairs(LANGUAGES), ([id, language]) =>
-    [id, ...(language.alias || [])].map((label) => [label, { label, ...language }])
+    [id, ...(language.alias || [])].map((label) => [label, Object.assign({ label }, language )])
   )
 );
-const featuresById = mapValues(FEATURES, (feature, key) => ({ label: key, ...feature }))
+const featuresById = mapValues(FEATURES, (feature, key) => (Object.assign({ label: key }, feature )));
 
 class MonacoWebpackPlugin {
   constructor(options = {}) {
@@ -59,7 +59,7 @@ class MonacoWebpackPlugin {
     const publicPath = getPublicPath(compiler);
     const modules = [EDITOR_MODULE, ...languages, ...features];
     const workers = modules.map(
-      ({ label, alias, worker }) => worker && ({ label, alias, ...worker })
+      ({ label, alias, worker }) => worker && Object.assign({ label, alias }, worker)
     ).filter(Boolean);
     const rules = createLoaderRules(languages, features, workers, output, publicPath);
     const plugins = createPlugins(workers, output);

--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ const languagesById = fromPairs(
     [id, ...(language.alias || [])].map((label) => [label, Object.assign({ label }, language )])
   )
 );
-const featuresById = mapValues(FEATURES, (feature, key) => (Object.assign({ label: key }, feature )));
+const featuresById = mapValues(FEATURES, (feature, key) => Object.assign({ label: key }, feature ));
 
 class MonacoWebpackPlugin {
   constructor(options = {}) {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A webpack plugin for the Monaco Editor",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "./node_modules/.bin/webpack --config test/webpack.config.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A webpack plugin for the Monaco Editor",
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/.bin/webpack --config test/webpack.config.js"
+    "test": "node ./node_modules/webpack/bin/webpack.js --config test/webpack.config.js"
   },
   "repository": {
     "type": "git",

--- a/test/package.json
+++ b/test/package.json
@@ -1,9 +1,0 @@
-{
-  "name": "monaco-webpack-test",
-  "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
-  "scripts": {
-    "test": "node ../node_modules/webpack/bin/webpack.js --config webpack.config.js"
-  }
-}

--- a/test/webpack.config.js
+++ b/test/webpack.config.js
@@ -4,6 +4,7 @@ const path = require('path');
 module.exports = {
     mode: 'development',
     entry: './index.js',
+    context: __dirname,
     output: {
         path: path.resolve(__dirname, 'dist'),
         filename: 'app.js'


### PR DESCRIPTION
This PR refactors object spread/rest syntax into `Object.assign` to maintain compatibility with Node v6.x.

It also adds a `test` script to the root `package.json` (needing to switch to `./test` in order to run the tests was confusing)

One can verify that this works by running `npm test` using node v6.14.3

Closes #21 