### PR TITLE
Webpack createChildCompiler api will drop SingleEntryPlugin complication hook 

### DIFF
--- a/plugins/AddWorkerEntryPointPlugin.js
+++ b/plugins/AddWorkerEntryPointPlugin.js
@@ -15,9 +15,10 @@ function getCompilerHook(compiler, {id, entry, filename, chunkFilename, plugins}
     const childCompiler = compilation.createChildCompiler(id, outputOptions, [
       new WebWorkerTemplatePlugin(),
       new LoaderTargetPlugin('webworker'),
-      new SingleEntryPlugin(compiler.context, entry, 'main'),
     ]);
+    new SingleEntryPlugin(compiler.context, entry, 'main').apply(childCompiler);
     plugins.forEach((plugin) => plugin.apply(childCompiler));
+
     childCompiler.runAsChild(callback);
   }
 }


### PR DESCRIPTION
Fixes #2 

![20180910175600](https://user-images.githubusercontent.com/42128808/45293060-ad43fa00-b529-11e8-855c-8bc6317a6634.png)
