### PR TITLE
Remove untranspiled ES2015 from final output

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ function createLoaderRules(languages, features, workers, outputPath, publicPath)
       }
       return {
         getWorkerUrl: function (moduleId, label) {
-          const pathPrefix = (typeof window.__webpack_public_path__ === 'string' ? window.__webpack_public_path__ : ${JSON.stringify(publicPath)});
+          var pathPrefix = (typeof window.__webpack_public_path__ === 'string' ? window.__webpack_public_path__ : ${JSON.stringify(publicPath)});
           return (pathPrefix ? stripTrailingSlash(pathPrefix) + '/' : '') + paths[label];
         }
       };


### PR DESCRIPTION
This code is typically not going to be transpiled by most webpack configurations, since it is under node_modules. Therefore, it should not contain >ES5. Unfortunately, we still have to support IE11, and monaco-editor itself still seems to support IE11 too.

In our project we are intentionally using UglifyJS instead of UglifyES, to throw errors on untranspiled code, which is how I caught this.