### PR TITLE
Fix handlebars language loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,17 @@ Options can be passed in to `MonacoWebpackPlugin`. They can be used to generate 
   * default value: `''`.
 * `languages` (`string[]`) - include only a subset of the languages supported.
   * default value: `['apex', 'azcli', 'bat', 'clojure', 'coffee', 'cpp', 'csharp', 'csp', 'css', 'dockerfile', 'fsharp', 'go', 'handlebars', 'html', 'ini', 'java', 'javascript', 'json', 'less', 'lua', 'markdown', 'msdax', 'mysql', 'objective', 'perl', 'pgsql', 'php', 'postiats', 'powerquery', 'powershell', 'pug', 'python', 'r', 'razor', 'redis', 'redshift', 'ruby', 'rust', 'sb', 'scheme', 'scss', 'shell', 'solidity', 'sql', 'st', 'swift', 'typescript', 'vb', 'xml', 'yaml']`.
+  
+Some languages share the same web worker. If one of the following languages is included, you must also include the language responsible for instantiating their shared worker:
+
+| Language      | Instantiator  |
+| ------------- | ------------- |
+| javascript    | typescript    |
+| handlebars    | html          |
+| scss, less    | css           |
+
+
+
 * `features` (`string[]`) - include only a subset of the editor features.
   * default value: `['accessibilityHelp', 'bracketMatching', 'caretOperations', 'clipboard', 'codeAction', 'codelens', 'colorDetector', 'comment', 'contextmenu', 'coreCommands', 'cursorUndo', 'dnd', 'find', 'folding', 'fontZoom', 'format', 'goToDefinitionCommands', 'goToDefinitionMouse', 'gotoError', 'gotoLine', 'hover', 'inPlaceReplace', 'inspectTokens', 'iPadShowKeyboard', 'linesOperations', 'links', 'multicursor', 'parameterHints', 'quickCommand', 'quickOutline', 'referenceSearch', 'rename', 'smartSelect', 'snippets', 'suggest', 'toggleHighContrast', 'toggleTabFocusMode', 'transpose', 'wordHighlighter', 'wordOperations', 'wordPartOperations']`.
 

--- a/index.js
+++ b/index.js
@@ -83,6 +83,11 @@ function createLoaderRules(languages, features, workers, outputPath, publicPath)
     workerPaths['scss'] = workerPaths['css'];
   }
 
+  if (workerPaths['html']) {
+    // handlebars and html share the same worker
+    workerPaths['handlebars'] = workerPaths['html'];
+  }
+
   const globals = {
     'MonacoEnvironment': `(function (paths) {
       function stripTrailingSlash(str) {


### PR DESCRIPTION
Handlebars shares a worker with html in the same way that `javascript/typescript` and `css/less/scss` share workers. However, the handlebars/html association was missing from the `createLoaderRules`
function. This was causing a bad network request when the language was set to handlebars in the monaco-editor due to trying to load an undefined web worker.

This change associates the handlebars and html `workerPaths` to prevent these issues.