### PR TITLE
make it work with create-react-app v2

### DIFF
--- a/loaders/include.js
+++ b/loaders/include.js
@@ -3,11 +3,6 @@ const loaderUtils = require('loader-utils');
 module.exports.pitch = function pitch(remainingRequest) {
   const { globals = undefined, pre = [], post = [] } = loaderUtils.getOptions(this) || {};
 
-  // HACK: NamedModulesPlugin overwrites existing modules when requesting the same module via
-  // different loaders, so we need to circumvent this by appending a suffix to make the name unique
-  // See https://github.com/webpack/webpack/issues/4613#issuecomment-325178346 for details
-  this._module.userRequest = `include-loader!${this._module.userRequest}`;
-
   return [
     ...(globals
       ? Object.keys(globals).map((key) => `self[${JSON.stringify(key)}] = ${globals[key]};`)


### PR DESCRIPTION
Hello, is this code still necessary?

```
  // HACK: NamedModulesPlugin overwrites existing modules when requesting the same module via
  // different loaders, so we need to circumvent this by appending a suffix to make the name unique
  // See https://github.com/webpack/webpack/issues/4613#issuecomment-325178346 for details
  this._module.userRequest = `include-loader!${this._module.userRequest}`;
```

When using create-react-app v2, it throws this error:

```
ERROR in ./node_modules/monaco-editor/esm/vs/editor/editor.main.js
Module build failed: Thread Loader (Worker 4)
Cannot read property 'userRequest' of undefined
``

It's the same error as mentioned here:
https://github.com/Microsoft/monaco-editor-webpack-plugin/issues/16

After removing, it works as expected.