### PR TITLE
fixing a userRequest of undefined error

### DIFF
--- a/loaders/include.js
+++ b/loaders/include.js
@@ -6,7 +6,9 @@ module.exports.pitch = function pitch(remainingRequest) {
   // HACK: NamedModulesPlugin overwrites existing modules when requesting the same module via
   // different loaders, so we need to circumvent this by appending a suffix to make the name unique
   // See https://github.com/webpack/webpack/issues/4613#issuecomment-325178346 for details
-  this._module.userRequest = `include-loader!${this._module.userRequest}`;
+  if(this._module) {
+    this._module.userRequest = `include-loader!${this._module.userRequest}`;
+  }
 
   return [
     ...(globals


### PR DESCRIPTION
Added a guard around setting the userRequest for cases where this._module doesn't exist (like when running in thread loader)

Fixes #16