### PR TITLE
Mark all options as optional in the type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,18 +4,18 @@ export interface IMonacoEditorWebpackPluginOpts {
      * custom output path for worker scripts, relative to the main webpack `output.path`.
      * Defaults to ''.
      */
-    output: string;
+    output?: string;
 
     /**
      * Include only a subset of the languages supported.
      */
-    languages: string[];
+    languages?: string[];
 
     /**
      * Include only a subset of the editor features.
      * Use e.g. '!contextmenu' to exclude a certain feature.
      */
-    features: string[];
+    features?: string[];
 }
 
 export default class MonacoEditorWebpackPlugin {


### PR DESCRIPTION
Currently, the options object is optional, but none of the properties. That means if you pass an options object, you must pass _all_ options. This PR makes each individual option optional too, so you can pass only the ones you care about.