### PR TITLE
Fix __webpack_public_path__ within getWorkerUrl method

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,7 +117,7 @@ function createLoaderRules(languages, features, workers, outputPath, publicPath)
       }
       return {
         getWorkerUrl: function (moduleId, label) {
-          var pathPrefix = (typeof window.__webpack_public_path__ === 'string' ? window.__webpack_public_path__ : ${JSON.stringify(publicPath)});
+          var pathPrefix = (typeof __webpack_public_path__ === 'string' ? __webpack_public_path__ : ${JSON.stringify(publicPath)});
           return (pathPrefix ? stripTrailingSlash(pathPrefix) + '/' : '') + paths[label];
         }
       };


### PR DESCRIPTION
According to webpack's documentation, the `__webpack_public_path__` variable is _not_ in the global scope, but is instead a [free variable](https://stackoverflow.com/questions/12934929/what-are-free-variables) provided by a closure which webpack creates when it generates its runtime wrapper.

https://webpack.js.org/configuration/output/#outputpublicpath

`window.__webpack_public_path__` should just be `__webpack_public_path__`

closes #7