### PR TITLE
add baseUrl optiosn to fix next.js use

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,6 +8,11 @@ interface IMonacoEditorWebpackPluginOpts {
     output?: string;
 
     /**
+     * custom worker js require baseUrl
+     */
+    baseUrl?: string
+
+    /**
      * Include only a subset of the languages supported.
      */
     languages?: string[];


### PR DESCRIPTION
in next.js this plugin wiil generate `*.worker.js` to `.next` dir, but `next.js` don't allow web read this dir, so I change the config to like below, change output path to `public` path which path that `next.js` provider public static file server. 
but in browser monaco will request `localhost:3000/publicpublic/monaco-editor/editor.worker.js` because this plugin use `output` as `baseUrl` , so I add the `baseUrl` options to let monaco request the right path.
sorry for my bad english
```js
// @ts-check

const MONACO_DIR = path.join(__dirname, './node_modules/monaco-editor')
const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin');

module.exports = {
  webpack: (config, options) => {

    config.plugins = config.plugins || []

    config.module.rules.push({
      test: /\.css$/,
      include: MONACO_DIR,
      use: ['style-loader', 'css-loader'],
    })
    config.plugins.push(
      new MonacoWebpackPlugin({
        output: '../public/monaco-editor',
        baseUrl: '/monaco-editor',
      })
    )

    return config

  },
}
```