### PR TITLE
Fix invalid regex in getWorkerUrl

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -197,7 +197,7 @@ function createLoaderRules(languages: IFeatureDefinition[], features: IFeatureDe
         getWorkerUrl: function (moduleId, label) {
           var pathPrefix = ${pathPrefix};
           var result = (pathPrefix ? stripTrailingSlash(pathPrefix) + '/' : '') + paths[label];
-          if (/^((http:)|(https:)|(file:)|(\/\/))/.test(result)) {
+          if (/^((http:)|(https:)|(file:)|(\\/\\/))/.test(result)) {
             var currentUrl = String(window.location);
             var currentOrigin = currentUrl.substr(0, currentUrl.length - window.location.hash.length - window.location.search.length - window.location.pathname.length);
             if (result.substring(0, currentOrigin.length) !== currentOrigin) {


### PR DESCRIPTION
Fixes a typo introduced in #101 where the rendered regex was not escaped correctly.

```
$ npm run test
ERROR in ../node_modules/monaco-editor/esm/vs/editor/editor.api.js (include-loader!../node_modules/monaco-editor/esm/vs/editor/editor.api.js) 9:15
Module parse failed: Invalid regular expression: /^((http:)|(https:)|(file:)|(/: Unterminated group (9:15)
File was processed with these loaders:
 * ../out/loaders/include.js
You may need an additional loader to handle the result of these loaders.
|           var pathPrefix = typeof __webpack_public_path__ === 'string' ? __webpack_public_path__ : "";
|           var result = (pathPrefix ? stripTrailingSlash(pathPrefix) + '/' : '') + paths[label];
>           if (/^((http:)|(https:)|(file:)|(//))/.test(result)) {
|             var currentUrl = String(window.location);
|             var currentOrigin = currentUrl.substr(0, currentUrl.length - window.location.hash.length - window.location.search.length - window.location.pathname.length);
 @ ./index.js 2:0-77 4:0-13
```

Tested on local.