### PR TITLE
Add require('path') to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ npm install monaco-editor-webpack-plugin
 * `webpack.config.js`:
 ```js
 const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin');
+const path = require('path');
 
 module.exports = {
   entry: './index.js',


### PR DESCRIPTION
Added `require('path')` to this snippet of code in the README.

Most people might realize this right away from the error. But it took me some googling because I'm very unfamiliar with node, etc. So it seems better to have the snippet be 100% correct.