### PR TITLE
Use compiler.webpack if available

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
+import type * as webpack from 'webpack';
 import * as path from 'path';
-import * as webpack from 'webpack';
 import * as loaderUtils from 'loader-utils';
 import * as fs from 'fs';
 import { AddWorkerEntryPointPlugin } from './plugins/AddWorkerEntryPointPlugin';
@@ -139,7 +139,7 @@ class MonacoEditorWebpackPlugin implements webpack.WebpackPluginInstance {
       }
     });
     const rules = createLoaderRules(languages, features, workers, filename, publicPath, compilationPublicPath);
-    const plugins = createPlugins(workers, filename);
+    const plugins = createPlugins(compiler, workers, filename);
     addCompilerRules(compiler, rules);
     addCompilerPlugins(compiler, plugins);
   }
@@ -247,7 +247,9 @@ function createLoaderRules(languages: IFeatureDefinition[], features: IFeatureDe
   ];
 }
 
-function createPlugins(workers: ILabeledWorkerDefinition[], filename: string): AddWorkerEntryPointPlugin[] {
+function createPlugins(compiler: webpack.Compiler, workers: ILabeledWorkerDefinition[], filename: string): AddWorkerEntryPointPlugin[] {
+  const webpack = compiler.webpack ?? require('webpack');
+
   return (
     (<AddWorkerEntryPointPlugin[]>[])
       .concat(workers.map(({ id, entry }) =>


### PR DESCRIPTION
This will use `compiler.webpack` if it is available.
Otherwise, it will fall back to require webpack lazily.
This will make the plugin compatible with NextJS 10.

Closes https://github.com/microsoft/monaco-editor-webpack-plugin/issues/141