### PR TITLE
fix: Failed to execute 'importScripts' on 'WorkerGlobalScope': The URL xxx is invalid.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -234,6 +234,9 @@ function createLoaderRules(languages: IFeatureDefinition[], features: IFeatureDe
             var currentUrl = String(window.location);
             var currentOrigin = currentUrl.substr(0, currentUrl.length - window.location.hash.length - window.location.search.length - window.location.pathname.length);
             if (result.substring(0, currentOrigin.length) !== currentOrigin) {
+              if(/^(\\/\\/)/.test(result)) {
+                result = window.location.protocol + result
+              }
               var js = '/*' + label + '*/importScripts("' + result + '");';
               var blob = new Blob([js], { type: 'application/javascript' });
               return URL.createObjectURL(blob);


### PR DESCRIPTION
This commit is to fix 'Failed to execute 'importScripts' on 'WorkerGlobalScope': The URL xxx is invalid.' error when the worker's url starts with '//'